### PR TITLE
Add basic support for Ollama

### DIFF
--- a/ai-invoice-extractor/package.json
+++ b/ai-invoice-extractor/package.json
@@ -36,6 +36,7 @@
 		"commander": "^14.0.0",
 		"dotenv": "^16.5.0",
 		"figlet": "^1.8.1",
+		"ollama-ai-provider": "^1.2.0",
 		"pino": "^9.7.0",
 		"pino-pretty": "^13.0.0",
 		"zod": "^3.25.20",

--- a/ai-invoice-extractor/src/cli.ts
+++ b/ai-invoice-extractor/src/cli.ts
@@ -14,7 +14,7 @@ import { StringUtils } from "./utils/string"
 
 export type CliOptions = z.infer<typeof CliOptions>
 export const CliOptions = z.object({
-  vendor: z.enum(["openai", "mistral"]).optional(),
+  vendor: z.enum(["openai", "mistral", "ollama"]).optional(),
   model: z.string("AI model is required").optional(),
   key: z.string("AI API Key is required.").optional(),
   pretty: z.boolean("Output pretty JSON").default(false)

--- a/ai-invoice-extractor/src/extractors/extractor.ts
+++ b/ai-invoice-extractor/src/extractors/extractor.ts
@@ -5,6 +5,7 @@ import { FileUtils } from "@/utils/file"
 import { StringUtils } from "@/utils/string"
 import { createMistral } from "@ai-sdk/mistral"
 import { createOpenAI } from "@ai-sdk/openai"
+import { createOllama } from 'ollama-ai-provider';
 import { APICallError, type LanguageModelV1, NoObjectGeneratedError, generateObject } from "ai"
 import type { z } from "zod"
 
@@ -131,6 +132,14 @@ export class OpenAIExtractor extends BaseExtractor {
   }
 }
 
+export class OllamaExtractor extends BaseExtractor {
+  constructor(model: AnyString, apiKey: string) {
+    logger.debug(`Creating extractor ollama:${model} with apiKey: ${StringUtils.mask(apiKey)}`)
+    const ollama = createOllama({ apiKey })
+    super(ollama(model))
+  }
+}
+
 // ==============================
 // Factory (entry point)
 // ==============================
@@ -142,6 +151,8 @@ export class Extractor {
         return new OpenAIExtractor(config.model, config.apiKey)
       case "mistral":
         return new MistralExtractor(config.model, config.apiKey)
+      case "ollama":
+        return new OllamaExtractor(config.model, config.apiKey)
       default:
         throw new Error(`Unsupported vendor: ${(config as AiConfig).vendor}`)
     }


### PR DESCRIPTION
Hello

It looks like working with only API or model. I didn't implement a baseUrl change because I'm just using it locally directly.

```
./dist/cli -v ollama -m gemma3:4b-it-qat -k "fake-api" -p picture.jpg
```

A subsidiary question, in my case, because the model is so small I got many null and so it didn't match the schema. I adapted some part that are not in this MR because I think the mandatory field is something that would be done with another application. Are you interested that I providing these changes in another MR?

Cheers