### PR TITLE
Add support for type text/plain

### DIFF
--- a/ai-invoice-extractor/src/utils/file.ts
+++ b/ai-invoice-extractor/src/utils/file.ts
@@ -10,6 +10,7 @@ export type MimeType =
   | "image/webp"
   | "application/pdf"
   | "application/octet-stream"
+  | "text/plain"
 
 export const MIMETYPES: Record<string, MimeType> = {
   png: "image/png",
@@ -17,7 +18,8 @@ export const MIMETYPES: Record<string, MimeType> = {
   jpg: "image/jpeg",
   gif: "image/gif",
   webp: "image/webp",
-  pdf: "application/pdf"
+  pdf: "application/pdf",
+  txt: "text/plain",
 }
 
 /**


### PR DESCRIPTION
Hello

A bit related to https://github.com/WellApp-ai/Well/pull/3 but I think it will also be useful for other models.

Ollama doesn't support PDF by using `context.data`.

We can make it work by:

- Generate pictures from the PDF
- Extract the text from the PDF

I think that most digital invoices are "text extractable" with `pdftotext` for example.

Some part of the code are a bit ugly, don't hesitate to update it if there is a better way to do it.

Cheers