### PR TITLE
Accept null values in confidenceValue

### DIFF
--- a/ai-invoice-extractor/src/prompts/extract-invoice.prompt.ts
+++ b/ai-invoice-extractor/src/prompts/extract-invoice.prompt.ts
@@ -2,7 +2,7 @@ import { z } from "zod"
 import { zodToJsonSchema } from "zod-to-json-schema"
 
 const confidenceValue = z.object({
-  value: z.union([z.string(), z.number()]),
+  value: z.union([z.string(), z.number(), z.null()]),
   confidence: z.number().min(0).max(1)
 })
 


### PR DESCRIPTION
When testing with Claude, schema validation failed because unrecognised values were returned as null.