### PR TITLE
feat: add tests for the ai-recept-generator

### DIFF
--- a/ai-receipt-generator/pytest.ini
+++ b/ai-receipt-generator/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/ai-receipt-generator/requirements.txt
+++ b/ai-receipt-generator/requirements.txt
@@ -22,3 +22,4 @@ uvicorn[standard]>=0.29.0   # ASGI server to run FastAPI
 
 # === TESTING (optional) ===
 pytest>=8.2.0
+Faker

--- a/ai-receipt-generator/tests/test_config_loader.py
+++ b/ai-receipt-generator/tests/test_config_loader.py
@@ -1,0 +1,84 @@
+import pytest
+import yaml
+from pathlib import Path
+from core.config_loader import load_config, validate_config, resolve_api_key
+
+# --- Fixtures ---
+
+@pytest.fixture
+def valid_config_data():
+    return {
+        "openai_image": {
+            "model": "gpt-image-1",
+            "size": "1024x1024",
+            "quality": "high",
+            "api_key": "key_from_config"
+        },
+        "anthropic": {
+            "model": "claude-3-opus-20240229"
+        }
+    }
+
+@pytest.fixture
+def invalid_config_data():
+    return {
+        "openai_image": {
+            "model": "gpt-image-1"
+            # Missing size and quality
+        }
+    }
+
+# --- Tests ---
+
+def test_load_config(tmp_path: Path, valid_config_data: dict):
+    """Tests loading a valid YAML config file."""
+    config_file = tmp_path / "models.yaml"
+    config_file.write_text(yaml.dump(valid_config_data), encoding="utf-8")
+    
+    config = load_config(config_file)
+    assert config == valid_config_data
+
+def test_load_missing_config(tmp_path: Path):
+    """Tests behavior when the config file is missing."""
+    config = load_config(tmp_path / "non_existent.yaml")
+    assert config == {}
+
+def test_validate_config_success(valid_config_data: dict):
+    """Tests that a valid config passes validation."""
+    assert validate_config(valid_config_data) is True
+
+def test_validate_config_failure(invalid_config_data: dict, capsys):
+    """Tests that an invalid config fails validation and prints an error."""
+    assert validate_config(invalid_config_data) is False
+    captured = capsys.readouterr()
+    assert "Missing fields in openai_image" in captured.out
+    assert "size" in captured.out
+    assert "quality" in captured.out
+
+def test_resolve_api_key_from_config(valid_config_data: dict):
+    """Tests resolving API key when it's present in the config."""
+    key = resolve_api_key(valid_config_data, "openai_image")
+    assert key == "key_from_config"
+
+def test_resolve_api_key_from_env(monkeypatch, valid_config_data: dict):
+    """Tests resolving API key from environment variable as a fallback."""
+    # Remove key from config data for this test
+    config_without_key = valid_config_data.copy()
+    del config_without_key["openai_image"]["api_key"]
+    
+    monkeypatch.setenv("OPENAI_API_KEY", "key_from_env")
+    
+    key = resolve_api_key(config_without_key, "openai_image")
+    assert key == "key_from_env"
+
+def test_resolve_api_key_prefers_config_over_env(monkeypatch, valid_config_data: dict):
+    """Tests that the config key is preferred over the environment variable."""
+    monkeypatch.setenv("OPENAI_API_KEY", "key_from_env")
+    key = resolve_api_key(valid_config_data, "openai_image")
+    assert key == "key_from_config"
+
+def test_resolve_api_key_not_found():
+    """Tests that None is returned when no key is found."""
+    config = {"openai_image": {"model": "test"}}
+    key = resolve_api_key(config, "openai_image")
+    assert key is None

--- a/ai-receipt-generator/tests/test_core.py
+++ b/ai-receipt-generator/tests/test_core.py
@@ -1,20 +1,110 @@
+import pytest
 from core.data_generator import generate_receipt_data
 from core.prompt_renderer import generate_image_prompt
 from pathlib import Path
 import json
+import math
+
+# +++ Fixtures +++
+
+@pytest.fixture
+def default_style() -> dict:
+    """Loads the default style for tests."""
+    style_path = Path("src/core/prompts/styles/table_noire.json")
+    return json.loads(style_path.read_text(encoding="utf-8"))
+
+# +++ Data Generator Tests +++
 
 def test_generate_receipt_data_structure():
+    """Ensures the generated data has the correct structure and keys."""
     data = generate_receipt_data()
     assert isinstance(data, dict)
-    assert "transaction_id" in data
-    assert "merchant" in data
-    assert "items" in data
-    assert isinstance(data["items"], list)
+    
+    # Check top-level keys
+    expected_keys = [
+        "transaction_id", "merchant", "items", "transaction_amount",
+        "terminal", "card", "barcode"
+    ]
+    for key in expected_keys:
+        assert key in data, f"Missing top-level key: {key}"
 
-def test_image_prompt_generation():
+    # Check nested structures
+    assert "name" in data["merchant"]
+    assert "address" in data["merchant"]
+    assert "line1" in data["merchant"]["address"]
+    assert isinstance(data["items"], list)
+    assert len(data["items"]) > 0
+    assert "description" in data["items"][0]
+    assert "line_total" in data["items"][0]
+    assert "amount" in data["transaction_amount"]
+    assert "tax_amount" in data["transaction_amount"]
+
+def test_generate_receipt_with_overrides():
+    """Tests that overrides are correctly applied to the generated data."""
+    overrides = {
+        "merchant_name": "My Test Cafe",
+        "tax_rate": 0.20
+    }
+    data = generate_receipt_data(overrides=overrides)
+    
+    assert data["merchant"]["name"] == "My Test Cafe"
+    assert data["transaction_amount"]["tax_rate"] == "20%"
+
+def test_item_totals_are_calculated_correctly():
+    """Tests that totals are correctly calculated when specific items are provided."""
+    overrides = {
+        "items": [
+            {"description": "Coffee", "quantity": 2, "unit_price": 3.50},
+            {"description": "Cake", "quantity": 1, "unit_price": 5.00}
+        ],
+        "tax_rate": 0.1
+    }
+    data = generate_receipt_data(overrides=overrides)
+    
+    # Expected: (2 * 3.50) + (1 * 5.00) = 7.00 + 5.00 = 12.00
+    expected_ht_total = 12.00
+    expected_tax = 1.20
+    expected_ttc = 13.20
+    
+    assert math.isclose(float(data["transaction_amount"]["amount"]), expected_ht_total)
+    assert math.isclose(float(data["transaction_amount"]["tax_amount"]), expected_tax)
+    assert math.isclose(float(data["transaction_amount"]["amount_tendered"]), expected_ttc)
+    assert len(data["items"]) == 2
+    assert data["items"][0]["line_total"] == 7.00
+
+def test_total_override_generates_correct_sum():
+    """Tests that generated items sum up to the forced total."""
+    overrides = {
+        "total_ttc": 100.00,
+        "tax_rate": 0.25 # 1 + 0.25 = 1.25
+    }
+    # HT should be 100.00 / 1.25 = 80.00
+    data = generate_receipt_data(overrides=overrides, num_items=5)
+    
+    items_total = sum(item["line_total"] for item in data["items"])
+    
+    assert math.isclose(items_total, 80.00)
+    assert math.isclose(float(data["transaction_amount"]["amount_tendered"]), 100.00)
+
+# +++ Prompt Renderer Tests +++
+
+def test_image_prompt_generation(default_style):
+    """Tests that a valid prompt string is generated."""
     data = generate_receipt_data()
-    style_path = Path("core/prompts/styles/table_noire.json")
-    style = json.loads(style_path.read_text(encoding="utf-8"))
-    prompt = generate_image_prompt(data, style)
+    prompt = generate_image_prompt(data, default_style)
+    
     assert isinstance(prompt, str)
-    assert len(prompt.strip()) > 50  # the prompt must be non-trivial
+    assert len(prompt.strip()) > 50
+    assert "Generate a realistic photo" in prompt
+
+def test_image_prompt_contains_data(default_style):
+    """Ensures the generated prompt contains the JSON payload and style."""
+    data = generate_receipt_data(overrides={"merchant_name": "Prompt Test Store"})
+    prompt = generate_image_prompt(data, default_style)
+    
+    # Check that the data payload is embedded
+    assert '"name": "Prompt Test Store"' in prompt
+    
+    # Check that the style payload is embedded
+    style_json_string = json.dumps(default_style, indent=2)
+    assert style_json_string in prompt


### PR DESCRIPTION
I've included comprehensive and robust tests for the ai-receipt generator