### PR TITLE
feat(telemetry): add OTel Claude Code telemetry config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "https://us-central1-well-app-t-pjt-ef4b.cloudfunctions.net/well-app-t-crf-usce1-obsdash/otel",
+    "OTEL_LOG_TOOL_DETAILS": "1",
+    "OTEL_LOG_USER_PROMPTS": "1",
+    "OTEL_METRIC_EXPORT_INTERVAL": "60000",
+    "OTEL_LOGS_EXPORT_INTERVAL": "5000"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with OTel OTLP configuration
- Enables Claude Code to export usage telemetry (metrics, tools, prompts) to the observability dashboard
- Allows per-member intent categorization and waste Pareto analysis

## Test plan
- [ ] Verify Claude Code sessions in this repo export telemetry to the OTLP endpoint
- [ ] Confirm events appear in the observability dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a repo-local Claude Code telemetry configuration that exports logs/metrics to an external OTLP endpoint; risk is mainly inadvertent telemetry/prompt data export if enabled in developer environments.
> 
> **Overview**
> Adds `.claude/settings.json` to enable Claude Code telemetry and configure OTLP log/metric export (including tool details and user prompts) to the specified observability endpoint with set export intervals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0265f57331305da9d521103bdccd0f8c987ed494. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->