### PR TITLE
feat(plugin): Well Claude Code plugin + marketplace (OAuth MCP + finance skills)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "well",
+  "owner": {
+    "name": "Well",
+    "url": "https://wellapp.ai"
+  },
+  "metadata": {
+    "description": "Well's official Claude plugin — connect your financial data (invoices, companies, contacts, the accounting ledger) and ship finance workflows."
+  },
+  "plugins": [
+    {
+      "name": "well",
+      "source": "./plugins/well",
+      "description": "Connect Claude to your Well financial data over a hosted OAuth MCP, with skills for building a compte de résultat / balance sheet, reconciling transactions, and querying the financial graph correctly.",
+      "category": "productivity",
+      "author": {
+        "name": "Well"
+      },
+      "homepage": "https://docs.wellapp.ai/mcp/introduction",
+      "keywords": ["finance", "accounting", "invoices", "bookkeeping", "mcp", "well", "ledger"]
+    }
+  ]
+}

--- a/plugins/well/.claude-plugin/plugin.json
+++ b/plugins/well/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "well",
+  "description": "Connect Claude to your Well financial data — invoices, companies, contacts, transactions, and the accounting ledger — over a hosted OAuth MCP, with skills for real financial workflows.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Well",
+    "url": "https://wellapp.ai"
+  },
+  "homepage": "https://docs.wellapp.ai/mcp/introduction",
+  "mcpServers": {
+    "well": {
+      "type": "http",
+      "url": "https://api.wellapp.ai/v1/mcp"
+    }
+  }
+}

--- a/plugins/well/README.md
+++ b/plugins/well/README.md
@@ -1,0 +1,57 @@
+# Well plugin
+
+Connect Claude to your **Well** financial data — invoices, companies, contacts, bank transactions, accounts, and the accounting ledger — and run real finance workflows.
+
+The plugin bundles Well's hosted **OAuth MCP server** (nothing to install, no API key) plus task skills for the things people actually ask for:
+
+- **`well:querying-well-data`** — discover the schema, then query the right root.
+- **`well:compte-de-resultat`** — build a P&L from the posted ledger (not raw invoices).
+- **`well:balance-sheet`** — build a bilan from the posted ledger / account balances.
+- **`well:reconciliation`** — match transactions to invoices; surface unpaid / unexplained items.
+
+## Install — Claude Code
+
+```bash
+/plugin marketplace add WellApp-ai/Well
+/plugin install well@well
+```
+
+Then run `/mcp`, select **well**, and **Authenticate** — a browser opens to sign in to Well. (Custom connectors / the hosted server require a Well account.)
+
+## Install — Claude Desktop / web (Cowork)
+
+The same server is a **custom connector**. In Claude: **Settings → Connectors → Add custom connector**, paste:
+
+```
+https://api.wellapp.ai/v1/mcp
+```
+
+and sign in. (Requires a paid Claude plan.)
+
+## Install — Codex
+
+Add the hosted MCP to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.well]
+command = "npx"
+args = ["-y", "mcp-remote", "https://api.wellapp.ai/v1/mcp"]
+```
+
+`mcp-remote` runs the OAuth browser flow on first connect. (Codex's native plugin support is evolving; the remote-MCP config above works today across MCP-capable clients.)
+
+## What you can ask
+
+- "Build my compte de résultat for Q1."
+- "What invoices are unpaid, and how much is outstanding?"
+- "Reconcile last month's bank transactions against my invoices."
+- "Show every company I've transacted with over €10k."
+
+## Tools the MCP exposes
+
+`well_get_schema`, `well_query_records`, `well_get_entity`, `well_add_contact_channel`, `well_remove_contact_channel`, `well_update_invoice`, `well_delete_invoice`.
+
+## Docs
+
+- Introduction: https://docs.wellapp.ai/mcp/introduction
+- Guides: https://github.com/WellApp-ai/Well/tree/main/docs/mcp

--- a/plugins/well/skills/balance-sheet/SKILL.md
+++ b/plugins/well/skills/balance-sheet/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: balance-sheet
+description: Build a balance sheet (bilan) from a Well workspace. Use when the user asks for a balance sheet, bilan, assets/liabilities/equity, or financial position at a point in time.
+---
+
+# Balance sheet (bilan) from Well
+
+Like the P&L, the balance sheet comes from the **posted ledger**, not from raw documents. It is a point-in-time snapshot: balances of the balance-sheet accounts as of a date.
+
+## Do this
+
+1. **Discover the schema** (`well:querying-well-data`):
+   - `well_get_schema("ledger_accounts")` — chart of accounts. Balance-sheet accounts are the asset/liability/equity classes (French plan comptable: classes 1–5; income-statement classes 6–7 are excluded).
+   - `well_get_schema("journal_entries")` / `journal_entry_lines` — posted movements with debit/credit and dates.
+   - `well_get_schema("account_balances")` — Well may expose computed balances directly; prefer these when present, they are the canonical balance per account.
+2. **As-of date**: filter postings with `date _lte <as_of>` (a balance sheet is cumulative from inception, not a period).
+3. **Compute each account balance** (sum of debits − credits, or read `account_balances`), then group by class:
+   - **Actif** (assets): debit-normal balances (classes 2, 3, 4-debit, 5).
+   - **Passif** (liabilities + equity): credit-normal balances (classes 1, 4-credit).
+4. **Check it balances**: total Actif must equal total Passif. If it doesn't, surface the gap rather than hiding it — it usually means unposted entries or a period filter mistake.
+
+## Do NOT
+
+- Do not derive assets/liabilities from invoice or bank-transaction lists directly; use the posted ledger / `account_balances`.
+- Do not assume account-class conventions without reading the chart of accounts.
+
+## If the ledger is empty
+
+Say the books aren't posted yet. A bank `accounts` + `account_balances` snapshot can give a **cash position** (not a balance sheet) as a clearly-labelled fallback.
+
+## Present it
+
+Two columns — **Actif** and **Passif** — grouped by class with subtotals, the as-of date, the currency, and an explicit "Actif = Passif ✓/✗" balance check.

--- a/plugins/well/skills/compte-de-resultat/SKILL.md
+++ b/plugins/well/skills/compte-de-resultat/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: compte-de-resultat
+description: Build a profit & loss statement (compte de résultat / income statement) from a Well workspace. Use when the user asks for a P&L, income statement, compte de résultat, revenue vs expenses, or net result over a period.
+---
+
+# Compte de résultat (P&L) from Well
+
+A correct income statement comes from the **posted accounting ledger**, not from raw invoices. Well's sync/posting pipelines post invoices and bank transactions into `journal_entries` against `ledger_accounts`; that posted data already handles classification, accruals, and settlement that a raw-invoice sum misses.
+
+## Do this
+
+1. **Discover the schema first** (see `well:querying-well-data`):
+   - `well_get_schema("ledger_accounts")` — the chart of accounts. Look for the account **code/number** and **name/type** fields; income-statement accounts are the revenue and expense classes (in a French plan comptable, classe 7 = produits, classe 6 = charges).
+   - `well_get_schema("journal_entries")` and `well_get_schema("journal_entry_lines")` if present — the posted movements with debit/credit amounts and the date you'll filter the period on.
+2. **Scope the period** with a `whereClause` on the posting/entry date (e.g. `_gte` start, `_lte` end).
+3. **Aggregate by account**: sum the posted amounts per ledger account, then group revenue accounts and expense accounts.
+4. **Net result** = total produits (revenue) − total charges (expenses).
+
+## Do NOT
+
+- **Do not reconstruct the P&L by summing issued invoices as revenue and received invoices as expenses.** That misses postings, non-invoice entries, accruals, and account classification, and double-counts or omits settlement. Use the ledger.
+- Do not hardcode account codes you haven't confirmed from `well_get_schema`/the data — read the chart of accounts first.
+
+## If the ledger is empty
+
+If `journal_entries` / `ledger_accounts` return no rows for the workspace, the books may not be posted yet. Say so explicitly, and only then offer an invoice-based **approximation** — clearly labelled as an estimate, not the compte de résultat — built from `invoices` (issued = revenue proxy, received = expense proxy) over the period.
+
+## Present it
+
+Group the output as: Produits (revenue) lines → total; Charges (expense) lines → total; **Résultat net**. Note the currency and the period. Offer a month-by-month or category breakdown as a follow-up.

--- a/plugins/well/skills/querying-well-data/SKILL.md
+++ b/plugins/well/skills/querying-well-data/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: querying-well-data
+description: How to query a Well workspace correctly — discover the schema first, then query the right root. Use whenever the user asks about their invoices, companies, contacts, bank transactions, accounts, or accounting ledger in Well, or before writing any well_query_records call.
+---
+
+# Querying Well data
+
+Well exposes a workspace's financial graph through three MCP tools:
+
+- `well_get_schema()` — list every available **root** (entity type).
+- `well_get_schema({ root })` — list the fields available on one root, with types and semantic context.
+- `well_query_records({ root, fields, whereClause?, orderBy?, limit? })` — read rows.
+- `well_get_entity({ root, id })` — fetch one record by id.
+
+## The one rule: discover before you query
+
+**Always call `well_get_schema(root)` first**, pick the fields you need from what it returns, then call `well_query_records`. Field paths are arrays: `"invoices.issuer.name"` → `["invoices", "issuer", "name"]`. Do not guess field names — they vary by root and are documented in the schema response (each field carries a `type` and often a `context` explaining what it means).
+
+## The roots you can read
+
+Calling `well_get_schema()` with no argument returns the full set. It includes far more than invoices and companies — in particular the **accounting graph**:
+
+- **Commercial documents:** `invoices`, `invoice_items`, `invoice_transactions`
+- **Parties:** `companies`, `people`, `payment_means`
+- **Banking:** `accounts`, `transactions`, `account_balances`
+- **Accounting graph (read-only, posted by Well's pipelines):** `ledger_accounts`, `journals`, `journal_entries`
+- **Reference:** `tax_rates`, `exchange_rates`, `categories`, `connectors`
+- **Workspace:** `memberships`, `tasks`, `workspace_connectors`
+
+If you are about to answer a financial question by reconstructing it from raw invoices, **stop and check `well_get_schema()` first** — the posted ledger (`journal_entries`, `ledger_accounts`) is almost always the correct, more accurate source. See the `well:compte-de-resultat` and `well:balance-sheet` skills.
+
+## Filtering
+
+`whereClause` is a Hasura-style boolean expression. Use the operator the field's `type` allows (from the schema):
+
+- `numeric` / `date` → `_eq`, `_gt`, `_lt`, `_gte`, `_lte`
+- `enum` → `_eq`, `_neq`, `_in`, `_nin`, `_is_null`
+- `text` → `_eq`, `_like`, `_ilike`
+- relations → nest: `{ "issuer": { "name": { "_ilike": "%acme%" } } }`
+
+## Gotchas
+
+- Reads are scoped to the authenticated workspace automatically — you never pass a workspace id.
+- Select the specific fields you need (5–15), not everything — it is faster and cheaper.
+- Amounts on commercial documents are in the document currency; check the schema `context` for currency fields before summing across currencies (see `exchange_rates`).

--- a/plugins/well/skills/reconciliation/SKILL.md
+++ b/plugins/well/skills/reconciliation/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: reconciliation
+description: Match bank transactions to invoices and surface unpaid / unmatched items in a Well workspace. Use when the user asks what's paid vs unpaid, to reconcile the bank, to find missing payments, or to match transactions to invoices.
+---
+
+# Reconciliation in Well
+
+Goal: connect money movement (`transactions`) to commercial documents (`invoices`) and report what is matched, unpaid, or unexplained.
+
+## What Well already links
+
+Well's pipelines maintain the link between a bank transaction and the invoice(s) it settles. Check the schema before computing matches by hand:
+
+1. `well_get_schema("invoice_transactions")` — the join between invoices and transactions, if exposed. Querying this root is the fastest path to "which invoices are settled by which transactions".
+2. `well_get_schema("invoices")` — look for a payment-status / amount-paid / outstanding field and the `grand_total`.
+3. `well_get_schema("transactions")` — amount, value/booking date, counterparty, and remittance fields.
+
+## Do this
+
+- **Unpaid invoices**: query `invoices` filtered on the payment-status / outstanding field the schema exposes (don't infer "unpaid" by subtracting sums if a status field exists). Sort by due date or amount.
+- **Matched**: read `invoice_transactions` (or the link the schema shows) to list invoice ↔ transaction pairs.
+- **Unmatched transactions**: `transactions` with no linked invoice — candidates for manual review (could be fees, transfers, or a missing invoice).
+- When matching by hand (no link exposed), match on **amount + date proximity + counterparty**, never on amount alone.
+
+## Do NOT
+
+- Do not declare an invoice paid purely because a transaction of the same amount exists — confirm via the link or counterparty + date.
+- Do not sum across currencies without converting (see `exchange_rates`).
+
+## Present it
+
+Three buckets — **Matched**, **Unpaid invoices**, **Unexplained transactions** — each with counts and totals, plus the currency. Offer to drill into any bucket with `well_get_entity`.


### PR DESCRIPTION
## What

Adds a one-click **Well plugin** + marketplace so users can install Well's MCP *and* finance know-how in one step:

```bash
/plugin marketplace add WellApp-ai/Well
/plugin install well@well
```

## Why this shape (best-practice research)

Modeled on how top proprietary SaaS plugins ship (PostHog `ai-plugin`, Airtable, Convex, Box, plus Stripe/Linear/Sentry in the official marketplace):

- **OAuth-first, no API key** — bundles the hosted remote MCP (`https://api.wellapp.ai/v1/mcp`); browser sign-in on first connect.
- **MCP + bundled skills** — the MCP is the floor; the *skills* are the differentiator (PostHog ships 30+). Skills encode how to use the data correctly.
- **Standard `marketplace.json` + `plugin.json`** metadata (name, description, author, category, homepage, keywords), self-referencing source `./plugins/well`.

## Contents

```
.claude-plugin/marketplace.json          # catalog (the "well" marketplace)
plugins/well/.claude-plugin/plugin.json  # manifest + the OAuth http MCP
plugins/well/skills/
  querying-well-data/      # discover schema first, query the right root
  compte-de-resultat/      # P&L from the POSTED LEDGER, not raw invoices
  balance-sheet/           # bilan from the ledger / account_balances
  reconciliation/          # match transactions↔invoices, surface unpaid
plugins/well/README.md     # install for Claude Code, Cowork, Codex
```

The skills directly fix the failure mode we hit in production: a model doing schema discovery concluded the accounting ledger was inaccessible and rebuilt a *compte de résultat* from raw invoices. `querying-well-data` + `compte-de-resultat` teach it to use `journal_entries`/`ledger_accounts` instead. (The two server-side bugs behind that — schema discovery hiding the ledger, and the user-scoped 500s — are fixed in platform PRs #3140 and #3139.)

## Multi-tool

README documents install for **Claude Code** (`/plugin`), **Claude Desktop/web Cowork** (custom connector, paste URL), and **Codex** (`~/.codex/config.toml` via `mcp-remote`).

## Distribution roadmap (after merge)

1. ✅ Own marketplace — `/plugin marketplace add WellApp-ai/Well` works as soon as this merges.
2. ⬜ Submit to the **community marketplace** (`anthropics/claude-plugins-community`) — self-serve, automated validation.
3. ⬜ Pursue **official marketplace** listing (curated by Anthropic — same category as Stripe/Linear/Sentry).

## Notes / follow-ups

- Skills intentionally avoid hard-coding field names — they instruct the model to call `well_get_schema(root)` first and read the chart of accounts, which is both safer and the correct pattern. Worth a quick review by someone close to the accounting model (the classe 6/7 and 1–5 framing) for wording.
- A `.codex-plugin/` native manifest can be added once that format stabilizes; today the `config.toml` snippet is the reliable Codex path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)