### PR TITLE
docs: "Add to Claude Code" plugin install + badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/opeojlhedogedjbonianohhoijlgknna.svg)](https://chrome.google.com/webstore/detail/opeojlhedogedjbonianohhoijlgknna)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Add to Claude Code](https://img.shields.io/badge/Claude%20Code-Add%20Well%20plugin-d97757)](#claude-code-plugin-one-click)
 
 ---
 
@@ -166,13 +167,24 @@ Connect your AI assistant to Well using the **Model Context Protocol (MCP)**.
 
 Query your invoices, companies, and contacts directly from Claude, Cursor, Windsurf, or ChatGPT.
 
-### Quick Start
+### Claude Code plugin (one-click)
+
+The fastest way to use Well in **Claude Code** — bundles the MCP **and** finance skills (build a compte de résultat, balance sheet, reconcile transactions), no API key:
+
+```
+/plugin marketplace add WellApp-ai/Well
+/plugin install well@well
+```
+
+Then run `/mcp`, select **well**, and **Authenticate** (browser sign-in). Run each command on its own line.
+
+### Quick Start (any MCP client)
 
 ```
 https://api.wellapp.ai/v1/mcp
 ```
 
-Add this URL to your MCP client and authenticate with your Well account.
+Add this URL to your MCP client and authenticate with your Well account. In **Claude Desktop / web**: Settings → Connectors → Add custom connector. In **Codex**: add it to `~/.codex/config.toml` via `mcp-remote`.
 
 ### Documentation
 
@@ -186,10 +198,13 @@ Add this URL to your MCP client and authenticate with your Well account.
 
 | Tool | Description |
 |------|-------------|
-| `well_get_schema` | Discover available data types and fields |
-| `well_query_records` | Query invoices, companies, people, documents |
-| `well_create_company` | Create a new company |
-| `well_create_person` | Create a new contact |
+| `well_get_schema` | Discover available roots and fields |
+| `well_query_records` | Query invoices, companies, people, transactions, the accounting ledger, … |
+| `well_get_entity` | Fetch a single record by id |
+| `well_add_contact_channel` | Add an email/phone to a company or person |
+| `well_remove_contact_channel` | Remove a contact channel |
+| `well_update_invoice` | Update fields on an invoice |
+| `well_delete_invoice` | Delete an invoice |
 
 For full documentation, visit [docs.wellapp.ai/mcp](https://docs.wellapp.ai/mcp)
 

--- a/docs/mcp/QUICKSTART.md
+++ b/docs/mcp/QUICKSTART.md
@@ -8,7 +8,18 @@ Get Well MCP running in 5 minutes.
 - API key from [Settings > API Keys](https://app.wellapp.ai/settings/api-keys)
 - Node.js 18+ (for local mode only)
 
-## Option 1: Remote Server (OAuth) - Recommended
+## Option 1: Claude Code plugin (one-click) - Recommended for Claude Code
+
+Bundles the MCP **and** finance skills (compte de résultat, balance sheet, reconciliation), no API key:
+
+```
+/plugin marketplace add WellApp-ai/Well
+/plugin install well@well
+```
+
+Then run `/mcp`, select **well**, and **Authenticate**. (Each command on its own line.)
+
+## Option 2: Remote Server (OAuth) - any MCP client
 
 Add this URL to your MCP client:
 


### PR DESCRIPTION
## What

- **README**: an **Add to Claude Code** badge + a "Claude Code plugin (one-click)" section with the install snippet:
  ```
  /plugin marketplace add WellApp-ai/Well
  /plugin install well@well
  ```
  plus Cowork (custom connector) and Codex (`config.toml`) pointers.
- **docs/mcp/QUICKSTART.md**: leads with the plugin option.
- **Fix**: the README MCP tool table listed `well_create_company` / `well_create_person`, which are **not registered tools**. Replaced with the real set (`well_get_schema`, `well_query_records`, `well_get_entity`, `well_add_contact_channel`, `well_remove_contact_channel`, `well_update_invoice`, `well_delete_invoice`).

## Context

Follows the plugin merge (#302). `claude plugin validate` passes for both the marketplace and the plugin manifest, so it clears the community-marketplace review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)