### PR TITLE
feat(plugin): add 4 finance skills (cash-flow, VAT, AR aging, month-end close)

### DIFF
--- a/plugins/well/README.md
+++ b/plugins/well/README.md
@@ -8,6 +8,10 @@ The plugin bundles Well's hosted **OAuth MCP server** (nothing to install, no AP
 - **`well:compte-de-resultat`** — build a P&L from the posted ledger (not raw invoices).
 - **`well:balance-sheet`** — build a bilan from the posted ledger / account balances.
 - **`well:reconciliation`** — match transactions to invoices; surface unpaid / unexplained items.
+- **`well:cash-flow-forecast`** — forecast cash flow and runway from booked invoices + collected transactions.
+- **`well:vat-summary`** — VAT / sales-tax summary for a period from the posted ledger (output − input VAT).
+- **`well:ar-aging`** — accounts-receivable aging + a verified "to chase" list (never chases settled invoices).
+- **`well:month-end-close`** — a close checklist: is everything reconciled and posted before closing the period.
 
 ## Install — Claude Code
 

--- a/plugins/well/skills/ar-aging/SKILL.md
+++ b/plugins/well/skills/ar-aging/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: ar-aging
+description: Produce an accounts-receivable aging report and surface overdue invoices for a Well workspace. Use when the user asks who owes them money, an AR aging report, overdue invoices, days sales outstanding (DSO), or which customers to chase.
+---
+
+# Accounts-receivable aging from Well
+
+Collections is **judgment, not nagging**. The point of an aging report is to chase the right customers — firmly where their payment history warrants it, gently where it doesn't — and to **never chase an invoice that was already paid, disputed, or credited**. Verify status before recommending any chase.
+
+## Build it
+
+1. **Discover the schema first** (see `well:querying-well-data`).
+2. **Open receivables** — issued `invoices` filtered on the payment-status / outstanding field the schema exposes (don't infer "unpaid" by subtracting sums if a status field exists). Pull due date, outstanding amount, and the customer (`companies`).
+3. **Confirm what's actually settled** — cross-check against `transactions` / `invoice_transactions` so a payment already received but not yet reflected in status isn't counted as overdue. This is the `well:reconciliation` sibling skill — reuse it.
+4. **Bucket by age** from the due date: Current (not yet due), 1–30, 31–60, 61–90, 90+ days overdue. Total per bucket and per customer.
+5. **Per-customer behavior** — where history exists, note each customer's typical days-to-pay so the user can prioritise (a chronic late-payer ≠ a first-time slip).
+
+## Rules
+
+- **Verify status before chasing.** Exclude paid / disputed / credited invoices from "to chase" — chasing a settled invoice is the fastest way to lose trust.
+- Sort the chase list by amount × overdue age, but annotate each with the customer's payment tier.
+- Don't sum across currencies without converting (`exchange_rates`).
+- Report **DSO** (days sales outstanding) only with the window it's computed over.
+
+## Present it
+
+An aging table (buckets × totals), a top "to chase" list (verified-open only, with each customer's payment behavior), DSO with its window, and the total outstanding — in the workspace currency.

--- a/plugins/well/skills/cash-flow-forecast/SKILL.md
+++ b/plugins/well/skills/cash-flow-forecast/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: cash-flow-forecast
+description: Forecast cash flow and runway for a Well workspace from booked invoices and collected bank transactions. Use when the user asks for a cash-flow forecast, runway, how long until they run out of cash, projected balance, or expected inflows/outflows.
+---
+
+# Cash-flow forecast from Well
+
+A trustworthy forecast is grounded in **what actually happened** — invoices raised, cash collected, and observed days-to-pay — not in optimistic projections. Every forecast must state its **time window and filters**, and flag thin history explicitly.
+
+## Build it from booked + collected
+
+1. **Discover the schema first** (see `well:querying-well-data`).
+2. **Starting position** — current cash: `well_get_schema("account_balances")` / `accounts`, sum the latest balance per account (note the currency).
+3. **Expected inflows (booked)** — open `invoices` (issued, unpaid) with their due dates and outstanding amounts. Adjust each due date by the customer's observed **days-to-pay** where history exists (derive from past `invoices` + their settling `transactions` / `invoice_transactions`).
+4. **Expected outflows (booked)** — received/payable `invoices` with due dates; plus recurring outflows visible in `transactions` history (rent, payroll, subscriptions).
+5. **Project** the balance forward per period (week or month): starting cash + expected inflows − expected outflows. Report the projected balance per period and the **runway** (the period the balance crosses zero, if any).
+
+## Rules
+
+- **State the window and filters** behind the forecast (e.g. "next 13 weeks, EUR, excludes intra-account transfers"). A forecast without its assumptions is a vanity number.
+- **Flag thin history.** If days-to-pay or recurring-outflow history is sparse (low n), say so — confidence is overstated on thin data.
+- Distinguish **booked** (invoices/contracts that exist) from **assumed** (run-rate extrapolation), and label which is which.
+- Don't sum across currencies without converting (see `exchange_rates`).
+
+## Present it
+
+A per-period table — opening balance, inflows, outflows, closing balance — the runway in plain terms ("≈ N weeks at current trajectory"), the stated window/filters, and an explicit confidence note when history is thin.

--- a/plugins/well/skills/month-end-close/SKILL.md
+++ b/plugins/well/skills/month-end-close/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: month-end-close
+description: Run a month-end (or period) close checklist against a Well workspace — verify everything is reconciled and posted before the books are closed. Use when the user asks to close the month/period, run a close checklist, check if the books are ready to close, or what's left before closing.
+---
+
+# Month-end close from Well
+
+Closing is a **repeatable checklist, not a heroic event** — and every step has a manual fallback, because the day it breaks is the day it matters. The close is what *produces* the financials: once the period is reconciled and posted, the P&L, balance sheet, and tax figures fall out of it (see `well:compte-de-resultat`, `well:balance-sheet`, `well:vat-summary`).
+
+## The checklist
+
+1. **Discover the schema first** (see `well:querying-well-data`) and fix the period (date range).
+2. **Bank reconciliation** — every `transactions` row in the period is matched to its invoice(s) or categorised; no unexplained movements. Use `well:reconciliation`. Confirm `account_balances` match the bank's closing balance.
+3. **Receivables / payables** — open `invoices` reviewed; nothing miscoded; AR aging sane (`well:ar-aging`).
+4. **Posting status** — every transaction and invoice in the period is **posted to a journal entry** (not left DRAFT). Query `journal_entries` for the period and flag any source document with no posted entry — those are the gaps that block a clean close.
+5. **Balances** — trial balance balances (total debits = total credits) across `ledger_accounts` / `journal_entries`; `account_balances` reconciled.
+6. **Tax** — VAT/tax for the period computed from the now-posted ledger (`well:vat-summary`).
+
+## Rules
+
+- **Report readiness, don't fake it.** If anything is unreconciled, unposted, or unbalanced, list it as a blocker — do not declare the period closed.
+- Each blocker should name the specific document/account and what's missing, so it's actionable.
+- Incremental is fine: surface "N of M done, here are the M−N gaps" rather than all-or-nothing.
+
+## Present it
+
+A checklist with pass/blocker per item, a list of specific gaps (each naming the document/account + what's needed), the trial-balance debits=credits check, and a clear verdict: **ready to close** or **N blockers remain**.

--- a/plugins/well/skills/vat-summary/SKILL.md
+++ b/plugins/well/skills/vat-summary/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: vat-summary
+description: Produce a VAT / sales-tax summary for a period from a Well workspace's posted ledger. Use when the user asks for a VAT return, VAT summary, sales tax owed, output vs input VAT, or tax declaration figures for a period.
+---
+
+# VAT summary from Well
+
+A VAT return is a **byproduct of closed books**, not a separate project. If the ledger is posted and correct, the figures already exist — the work is presentation. Work **backward from the filing deadline** and **forward from the posted ledger**, and surface uncertainty rather than reporting a number you're not sure of.
+
+## Build it from the posted ledger + tax rates
+
+1. **Discover the schema first** (see `well:querying-well-data`).
+2. **Output VAT (collected on sales)** — from issued `invoices` / `invoice_items` and their `tax_rates`, or the corresponding VAT `ledger_accounts` / `journal_entries` for the period. Group by rate (standard / reduced / zero / exempt).
+3. **Input VAT (paid on purchases)** — from received `invoices` / `invoice_items` + `tax_rates`, or the input-VAT ledger accounts.
+4. **Net VAT due** = output VAT − recoverable input VAT, per the period's date filter.
+5. **By rate and jurisdiction** — break the totals down by VAT rate and, for multi-jurisdiction workspaces, by jurisdiction. Read the rate from the data (`tax_rates`), don't assume it.
+
+## Rules — conservative by design
+
+- **"The books are not closed yet."** If the period's `journal_entries` are still DRAFT / unposted, say so before producing a final figure — declarations fall out of *closed* books. Offer a provisional figure clearly labelled as such.
+- **Surface uncertainty, don't file it.** Where a rate, exemption, or jurisdiction treatment is ambiguous, flag it for human review rather than guessing.
+- Read rates and jurisdictions from `tax_rates` / the data; never hardcode a percentage.
+- Don't sum across currencies without converting (`exchange_rates`).
+
+## Present it
+
+Output VAT (by rate) → total; Input VAT (by rate) → total; **Net VAT due**; the period and jurisdiction; a books-closed/draft status line; and any flagged uncertainties for review.


### PR DESCRIPTION
## What

Doubles the Well plugin's bundled skill set from 4 → 8, so Claude is competent at more FinOps tasks the moment the plugin is installed. Each new skill is **grounded in Well's actual product domain** (derived from the owning runtime agent spec + the matching backend service), not invented:

| Skill | Grounded in | What it does |
|---|---|---|
| `cash-flow-forecast` | `box` (revenue intelligence) + `codd` cash-flow-forecasting + `account_balances`/`transactions`/`invoices` | Runway from **booked + collected** history; states window/filters; flags thin history |
| `vat-summary` | `pacioli` (tax & filing) + `statutory-tax.service` / `tax-rate-resolver` + `tax_rates`/ledger | Output − input VAT from the **posted ledger**; says "books not closed" on DRAFT entries; surfaces uncertainty |
| `ar-aging` | `dun` (AR collections) + `collect.service` + `invoices`/`companies`/`transactions` | Aging buckets + a **verified** to-chase list that never chases settled invoices; per-customer behavior |
| `month-end-close` | `brooks` (close automation) + `accounting/period-close.service` + `journal_entries`/`ledger_accounts` | Close checklist (reconciled + posted + balanced); reports readiness, names specific blockers |

## Faithful to the product

- All four are **schema-first** — they call `well_get_schema` before querying and never hard-code field names.
- All four use the **posted ledger** (`journal_entries` / `ledger_accounts`), not raw invoices — the lesson from the original "model rebuilt a P&L from invoices" failure.
- Each mirrors its agent's worldview: pacioli's "a return falls out of closed books," dun's "never chase a settled invoice," box's "state the window + flag low-n," brooks' "report readiness, don't fake it."

## Verification

`claude plugin validate ./plugins/well` passes. README skill list updated. No code changes — skills + docs only.

## Why this matters (activation)

Bundled skills are the plugin's biggest activation lever (the PostHog model): each new skill is a new "it just works" first-run moment. This batch covers the most-asked FinOps questions — runway, VAT, who-owes-me, can-I-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)