### PR TITLE
feat(plugin): automate MCP install + connect (team auto-install, /well:connect)

### DIFF
--- a/plugins/well/.claude-plugin/plugin.json
+++ b/plugins/well/.claude-plugin/plugin.json
@@ -1,7 +1,8 @@
 {
   "name": "well",
-  "description": "Connect Claude to your Well financial data — invoices, companies, contacts, transactions, and the accounting ledger — over a hosted OAuth MCP, with skills for real financial workflows.",
-  "version": "0.1.0",
+  "description": "Connect Claude to your Well financial data — invoices, companies, contacts, transactions, and the accounting ledger — over a hosted OAuth MCP, with skills for real financial workflows. Installing the plugin auto-configures the MCP server; run /well:connect to authenticate.",
+  "version": "0.2.0",
+  "defaultEnabled": true,
   "author": {
     "name": "Well",
     "url": "https://wellapp.ai"

--- a/plugins/well/README.md
+++ b/plugins/well/README.md
@@ -11,12 +11,35 @@ The plugin bundles Well's hosted **OAuth MCP server** (nothing to install, no AP
 
 ## Install — Claude Code
 
+Installing the plugin **auto-configures the MCP server** (it's bundled in the plugin — you never run `claude mcp add`). Two steps, each on its own line:
+
 ```bash
-/plugin marketplace add WellApp-ai/Well
-/plugin install well@well
+/plugin marketplace add WellApp-ai/Well   # 1. register the catalog
+/plugin install well@well                 # 2. install the plugin (+ MCP + skills)
 ```
 
-Then run `/mcp`, select **well**, and **Authenticate** — a browser opens to sign in to Well. (Custom connectors / the hosted server require a Well account.)
+> `marketplace add` only registers the catalog — it does **not** install anything. You must also run `install`. (If you only ran step 1 and "nothing happened," step 2 is what you're missing.)
+
+Then connect:
+
+```bash
+/well:connect
+```
+
+`/well:connect` walks you through the one-time browser sign-in (`/mcp` → **well** → **Authenticate** — no API key), verifies the tools respond, and shows what to ask. Run `/reload-plugins` first if the plugin was just installed.
+
+### Team / repo auto-install
+
+To install the plugin for a whole team automatically, copy [`examples/team-settings.json`](./examples/team-settings.json) into your repo's `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": { "well": { "source": { "source": "github", "repo": "WellApp-ai/Well" } } },
+  "enabledPlugins": ["well@well"]
+}
+```
+
+When a teammate trusts the repo, Claude Code prompts to add the marketplace **and** install the plugin in one step. Each user still authenticates once with `/well:connect`.
 
 ## Install — Claude Desktop / web (Cowork)
 

--- a/plugins/well/examples/team-settings.json
+++ b/plugins/well/examples/team-settings.json
@@ -1,0 +1,12 @@
+{
+  "//": "Copy this into your repo's .claude/settings.json to auto-install the Well plugin for your team. When a teammate trusts the repo, Claude Code prompts to add the marketplace AND install the plugin in one step — no manual /plugin marketplace add + /plugin install. They still authenticate once via /well:connect.",
+  "extraKnownMarketplaces": {
+    "well": {
+      "source": {
+        "source": "github",
+        "repo": "WellApp-ai/Well"
+      }
+    }
+  },
+  "enabledPlugins": ["well@well"]
+}

--- a/plugins/well/hooks/hooks.json
+++ b/plugins/well/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"The Well plugin is installed and bundles the well MCP server (financial data). If the user asks about their Well invoices/transactions/ledger and the well_* tools are not connected, guide them with the /well:connect skill: run /mcp, select well, Authenticate (browser sign-in, no API key). Do not surface this unless relevant.\"}}'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/well/skills/connect/SKILL.md
+++ b/plugins/well/skills/connect/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: connect
+description: Connect and verify the Well MCP — authenticate, confirm the tools work, and show what to ask. Use when the user runs /well:connect, just installed the Well plugin, or says the Well connection/MCP "isn't working" / "nothing happened".
+disable-model-invocation: false
+---
+
+# Connect to Well
+
+Run this right after installing the Well plugin, or whenever the Well tools aren't responding. Walk the user through it conversationally — do not dump all steps at once if a step is already done.
+
+## 1. Confirm the MCP server is registered
+
+Installing the plugin auto-adds the `well` MCP server (it is bundled in the plugin manifest). If the user just installed it, make sure it's active:
+
+- Tell them to run `/reload-plugins` if they haven't since installing.
+- The server should now appear when they run `/mcp`.
+
+## 2. Authenticate (one time, browser sign-in — no API key)
+
+The Well MCP uses OAuth, so the first connection needs a one-time sign-in:
+
+> Run `/mcp`, select **well**, and choose **Authenticate**. A browser opens — sign in to your Well account and approve. No API key, no config.
+
+If `/mcp` shows **well** as already authenticated, skip this.
+
+## 3. Verify it works
+
+Call `well_get_schema` (no arguments) to confirm the connection is live. If it returns the list of roots (companies, invoices, transactions, ledger_accounts, …), the connection is working — tell the user "Connected ✓, N data types available."
+
+If it returns an auth error, send them back to step 2. If it returns a server error on the heavy roots, the connection is fine but the workspace data path may be temporarily unavailable — say so rather than implying the setup failed.
+
+## 4. Show what to ask
+
+Once connected, offer 3 concrete starting prompts so the user gets value immediately:
+
+- "Summarize last month's cash flow"
+- "List my unpaid invoices over €5,000"
+- "Build my compte de résultat for the last quarter"
+
+Mention the deeper skills are available too: `/well:reconciliation`, `/well:vat-summary`, `/well:ar-aging`, `/well:month-end-close`, `/well:compte-de-resultat`, `/well:balance-sheet`, `/well:cash-flow-forecast`.
+
+## Note on billing
+
+Tool calls use Well credits, billed to the workspace plan. Mention this once if the user asks about cost — do not interrupt every call.


### PR DESCRIPTION
## Why

When a user runs `/plugin marketplace add WellApp-ai/Well`, Claude Code says "Successfully added marketplace" — but **nothing is installed yet** (that only registers the catalog). The next step `/plugin install well@well` is easy to miss → "nothing happened." This PR closes that gap and automates the install where it can be automated.

Important baseline: the plugin **already** bundles the MCP server (`mcpServers` in `plugin.json`), so installing the plugin **auto-configures `well`** — users never run `claude mcp add`. The only thing that can't (and shouldn't) be silent is the OAuth consent.

## What's in here

1. **Team / repo auto-install** — `examples/team-settings.json` with `extraKnownMarketplaces` + `enabledPlugins`. Drop it into a repo's `.claude/settings.json` and, on repo trust, Claude Code prompts to add the marketplace **and** install the plugin in **one step**. This is the real "automated installation" for teams (the plugin counterpart of a committed `.mcp.json`).

2. **`/well:connect` command** (`skills/connect`) — a guided one-shot: walks the one-time OAuth (`/mcp` → **well** → **Authenticate**, no API key), verifies `well_get_schema` responds, and shows 3 example prompts. Turns "marketplace added, now what?" into a confirmed connection.

3. **SessionStart hook** (`hooks/hooks.json`) — a lightweight context note so the model offers `/well:connect` when a user asks about Well data and the tools aren't connected. Non-visible; not a per-session nag.

4. **`defaultEnabled: true`** + version `0.2.0`, and the README now shows the **two-step** install explicitly with a callout: *"marketplace add registers the catalog — you must also run install."*

## The honest ceiling

Best achievable flow: **install plugin (auto-installs MCP) → `/well:connect` → one auth click → working.** You can't get to zero-click because Claude Code requires an explicit plugin install and OAuth consent is mandatory by design (you can't silently grant a tool access to financial data). The team `settings.json` (item 1) collapses the install to a single trust-prompt; `/well:connect` (item 2) collapses the post-install steps to one command.

## Verification

`claude plugin validate ./plugins/well` passes. JSON validated. Skills/hooks/examples added; no MCP/platform change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)