### PR TITLE
feat(skills): gate every figure on data coverage, and offer the control that fixes it

### DIFF
--- a/plugins/well/.claude-plugin/plugin.json
+++ b/plugins/well/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "well",
   "description": "Connect Claude to your Well financial data — invoices, companies, contacts, transactions, and the accounting ledger — over a hosted OAuth MCP, with skills for real financial workflows. Installing the plugin auto-configures the MCP server; run /well:connect to authenticate.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "defaultEnabled": true,
   "author": {
     "name": "Well",

--- a/plugins/well/README.md
+++ b/plugins/well/README.md
@@ -4,7 +4,8 @@ Connect Claude to your **Well** financial data — invoices, companies, contacts
 
 The plugin bundles Well's hosted **OAuth MCP server** (nothing to install, no API key) plus task skills for the things people actually ask for:
 
-- **`well:querying-well-data`** — discover the schema, then query the right root.
+- **`well:querying-well-data`** — pick the workspace, discover the schema, then query the right root.
+- **`well:data-coverage`** — check the data is complete enough to answer with (bank source connected, transactions categorized) before any figure is produced.
 - **`well:compte-de-resultat`** — build a P&L from the posted ledger (not raw invoices).
 - **`well:balance-sheet`** — build a bilan from the posted ledger / account balances.
 - **`well:reconciliation`** — match transactions to invoices; surface unpaid / unexplained items.
@@ -76,7 +77,11 @@ args = ["-y", "mcp-remote", "https://api.wellapp.ai/v1/mcp"]
 
 ## Tools the MCP exposes
 
-`well_get_schema`, `well_query_records`, `well_get_entity`, `well_add_contact_channel`, `well_remove_contact_channel`, `well_update_invoice`, `well_delete_invoice`.
+**Read** — `well_list_workspaces`, `well_get_schema`, `well_query_records`, `well_get_entity`, `well_list_connectors`, `well_list_connector_tools`, and the deterministic KPIs `well_get_runway`, `well_get_cash_position`, `well_get_cost_structure`, `well_get_investment_holdings`.
+
+**Write** — `well_create_company` / `well_update_company` / `well_delete_company`, the same three for `person`, `well_create_invoice_from_data`, `well_update_invoice`, `well_delete_invoice`, `well_add_contact_channel`, `well_remove_contact_channel`, `well_invoke_connector_tool`, `well_run_register_diff`, `well_resolve_reconciliation_task`, `well_resolve_register_diff_gap`.
+
+A write is refused rather than guessed when the connection authorizes several workspaces and no `workspace_id` is given.
 
 ## Docs
 

--- a/plugins/well/skills/ar-aging/SKILL.md
+++ b/plugins/well/skills/ar-aging/SKILL.md
@@ -9,11 +9,14 @@ Collections is **judgment, not nagging**. The point of an aging report is to cha
 
 ## Build it
 
-1. **Discover the schema first** (see `well:querying-well-data`).
-2. **Open receivables** — issued `invoices` filtered on the payment-status / outstanding field the schema exposes (don't infer "unpaid" by subtracting sums if a status field exists). Pull due date, outstanding amount, and the customer (`companies`).
-3. **Confirm what's actually settled** — cross-check against `transactions` / `invoice_transactions` so a payment already received but not yet reflected in status isn't counted as overdue. This is the `well:reconciliation` sibling skill — reuse it.
-4. **Bucket by age** from the due date: Current (not yet due), 1–30, 31–60, 61–90, 90+ days overdue. Total per bucket and per customer.
-5. **Per-customer behavior** — where history exists, note each customer's typical days-to-pay so the user can prioritise (a chronic late-payer ≠ a first-time slip).
+1. **Run the coverage gate** (see `well:data-coverage`). Missing bank transactions make
+   settled invoices read as overdue — which turns this report into a list of customers to
+   chase who already paid.
+2. **Discover the schema** (see `well:querying-well-data`).
+3. **Open receivables** — issued `invoices` filtered on the payment-status / outstanding field the schema exposes (don't infer "unpaid" by subtracting sums if a status field exists). Pull due date, outstanding amount, and the customer (`companies`).
+4. **Confirm what's actually settled** — cross-check against `transactions` / `invoice_transactions` so a payment already received but not yet reflected in status isn't counted as overdue. This is the `well:reconciliation` sibling skill — reuse it.
+5. **Bucket by age** from the due date: Current (not yet due), 1–30, 31–60, 61–90, 90+ days overdue. Total per bucket and per customer.
+6. **Per-customer behavior** — where history exists, note each customer's typical days-to-pay so the user can prioritise (a chronic late-payer ≠ a first-time slip).
 
 ## Rules
 
@@ -24,4 +27,4 @@ Collections is **judgment, not nagging**. The point of an aging report is to cha
 
 ## Present it
 
-An aging table (buckets × totals), a top "to chase" list (verified-open only, with each customer's payment behavior), DSO with its window, and the total outstanding — in the workspace currency.
+The coverage line first (`well:data-coverage`), then an aging table (buckets × totals), a top "to chase" list (verified-open only, with each customer's payment behavior), DSO with its window, and the total outstanding — in the workspace currency.

--- a/plugins/well/skills/balance-sheet/SKILL.md
+++ b/plugins/well/skills/balance-sheet/SKILL.md
@@ -9,15 +9,18 @@ Like the P&L, the balance sheet comes from the **posted ledger**, not from raw d
 
 ## Do this
 
-1. **Discover the schema** (`well:querying-well-data`):
+1. **Run the coverage gate** (see `well:data-coverage`) — a missing bank source shows up
+   here as an asset side that silently understates cash. Carry its coverage line into the
+   output.
+2. **Discover the schema** (`well:querying-well-data`):
    - `well_get_schema("ledger_accounts")` — chart of accounts. Balance-sheet accounts are the asset/liability/equity classes (French plan comptable: classes 1–5; income-statement classes 6–7 are excluded).
    - `well_get_schema("journal_entries")` / `journal_entry_lines` — posted movements with debit/credit and dates.
    - `well_get_schema("account_balances")` — Well may expose computed balances directly; prefer these when present, they are the canonical balance per account.
-2. **As-of date**: filter postings with `date _lte <as_of>` (a balance sheet is cumulative from inception, not a period).
-3. **Compute each account balance** (sum of debits − credits, or read `account_balances`), then group by class:
+3. **As-of date**: filter postings with `date _lte <as_of>` (a balance sheet is cumulative from inception, not a period).
+4. **Compute each account balance** (sum of debits − credits, or read `account_balances`), then group by class:
    - **Actif** (assets): debit-normal balances (classes 2, 3, 4-debit, 5).
    - **Passif** (liabilities + equity): credit-normal balances (classes 1, 4-credit).
-4. **Check it balances**: total Actif must equal total Passif. If it doesn't, surface the gap rather than hiding it — it usually means unposted entries or a period filter mistake.
+5. **Check it balances**: total Actif must equal total Passif. If it doesn't, surface the gap rather than hiding it — it usually means unposted entries or a period filter mistake.
 
 ## Do NOT
 
@@ -30,4 +33,4 @@ Say the books aren't posted yet. A bank `accounts` + `account_balances` snapshot
 
 ## Present it
 
-Two columns — **Actif** and **Passif** — grouped by class with subtotals, the as-of date, the currency, and an explicit "Actif = Passif ✓/✗" balance check.
+The coverage line first (`well:data-coverage`), then two columns — **Actif** and **Passif** — grouped by class with subtotals, the as-of date, the currency, and an explicit "Actif = Passif ✓/✗" balance check.

--- a/plugins/well/skills/cash-flow-forecast/SKILL.md
+++ b/plugins/well/skills/cash-flow-forecast/SKILL.md
@@ -5,23 +5,69 @@ description: Forecast cash flow and runway for a Well workspace from booked invo
 
 # Cash-flow forecast from Well
 
-A trustworthy forecast is grounded in **what actually happened** — invoices raised, cash collected, and observed days-to-pay — not in optimistic projections. Every forecast must state its **time window and filters**, and flag thin history explicitly.
+A trustworthy forecast is grounded in **what actually happened** — invoices raised,
+cash collected, and observed days-to-pay — not in optimistic projections. Every
+forecast must state its **time window and filters**, and flag thin history and
+missing data explicitly.
 
-## Build it from booked + collected
+## Start from the deterministic tools, not from raw reads
 
-1. **Discover the schema first** (see `well:querying-well-data`).
-2. **Starting position** — current cash: `well_get_schema("account_balances")` / `accounts`, sum the latest balance per account (note the currency).
-3. **Expected inflows (booked)** — open `invoices` (issued, unpaid) with their due dates and outstanding amounts. Adjust each due date by the customer's observed **days-to-pay** where history exists (derive from past `invoices` + their settling `transactions` / `invoice_transactions`).
-4. **Expected outflows (booked)** — received/payable `invoices` with due dates; plus recurring outflows visible in `transactions` history (rent, payroll, subscriptions).
-5. **Project** the balance forward per period (week or month): starting cash + expected inflows − expected outflows. Report the projected balance per period and the **runway** (the period the balance crosses zero, if any).
+**`well_get_runway` already computes runway** — cash on hand ÷ trailing-3-month
+average burn — server-side, applying the sign-convention detection,
+internal-transfer exclusion and FX conversion that a hand-rolled sum over
+`account_balances` gets wrong. It returns the exact figure the Well app shows,
+plus the completeness signals a re-derivation destroys:
+
+- `status`: `ok` · `capped` (>36 months — report as ">36 months") · `infinite`
+  (positive cash, not burning) · `insufficient_data`.
+- `partial` + `excluded: { accounts, transactions }` — rows left out.
+- `hints[]` — each a `detected_gap` with a `suggested_action`.
+
+`well_get_cash_position` does the same for the current position and its
+per-account breakdown.
+
+**Do not rebuild either from `well_query_records`.** Call the tool, then extend
+it with the forward-looking half below.
+
+## Run the coverage gate first
+
+See `well:data-coverage`. A forecast with no bank source, or with a period the
+sync never covered, is a number with a hole in it — check before computing, and
+carry the coverage line into the output. `status: "insufficient_data"` from
+`well_get_runway` is that gate answering: report it and point at
+`well_list_connectors`' `install_url`, don't substitute an estimate.
+
+## Build the forward half
+
+1. **Starting position** — `well_get_cash_position` (or the `cash` field of
+   `well_get_runway`). Note the currency.
+2. **Expected inflows (booked)** — open `invoices` (issued, unpaid) with due dates
+   and outstanding amounts. Adjust each due date by the customer's observed
+   **days-to-pay** where history exists (derive from past `invoices` + their
+   settling `transactions` / `invoice_transactions`).
+3. **Expected outflows (booked)** — received/payable `invoices` with due dates;
+   plus recurring outflows visible in `transactions` history (rent, payroll,
+   subscriptions).
+4. **Project** the balance forward per period (week or month): starting cash +
+   expected inflows − expected outflows. Report the projected balance per period
+   and the **runway** — reconciling against `well_get_runway`'s figure, and saying
+   so when the two disagree rather than silently preferring one.
 
 ## Rules
 
-- **State the window and filters** behind the forecast (e.g. "next 13 weeks, EUR, excludes intra-account transfers"). A forecast without its assumptions is a vanity number.
-- **Flag thin history.** If days-to-pay or recurring-outflow history is sparse (low n), say so — confidence is overstated on thin data.
-- Distinguish **booked** (invoices/contracts that exist) from **assumed** (run-rate extrapolation), and label which is which.
+- **State the window and filters** (e.g. "next 13 weeks, EUR, excludes
+  intra-account transfers"). A forecast without its assumptions is a vanity number.
+- **Carry `partial` / `excluded` / `hints` into the output.** A figure that
+  excluded 12 accounts is not the same figure as one that excluded none.
+- **Flag thin history.** If days-to-pay or recurring-outflow history is sparse
+  (low n), say so — confidence is overstated on thin data.
+- Distinguish **booked** (invoices/contracts that exist) from **assumed**
+  (run-rate extrapolation), and label which is which.
 - Don't sum across currencies without converting (see `exchange_rates`).
 
 ## Present it
 
-A per-period table — opening balance, inflows, outflows, closing balance — the runway in plain terms ("≈ N weeks at current trajectory"), the stated window/filters, and an explicit confidence note when history is thin.
+The coverage line first, then a per-period table — opening balance, inflows,
+outflows, closing balance — the runway in plain terms ("≈ N weeks at current
+trajectory"), the stated window/filters, the exclusion counts if any, and an
+explicit confidence note when history is thin.

--- a/plugins/well/skills/compte-de-resultat/SKILL.md
+++ b/plugins/well/skills/compte-de-resultat/SKILL.md
@@ -9,12 +9,15 @@ A correct income statement comes from the **posted accounting ledger**, not from
 
 ## Do this
 
-1. **Discover the schema first** (see `well:querying-well-data`):
+1. **Run the coverage gate** (see `well:data-coverage`) — uncategorized transactions and an
+   unsynced bank period both leave holes a posted-ledger sum cannot show you. Carry its
+   coverage line into the output.
+2. **Discover the schema** (see `well:querying-well-data`):
    - `well_get_schema("ledger_accounts")` — the chart of accounts. Look for the account **code/number** and **name/type** fields; income-statement accounts are the revenue and expense classes (in a French plan comptable, classe 7 = produits, classe 6 = charges).
    - `well_get_schema("journal_entries")` and `well_get_schema("journal_entry_lines")` if present — the posted movements with debit/credit amounts and the date you'll filter the period on.
-2. **Scope the period** with a `whereClause` on the posting/entry date (e.g. `_gte` start, `_lte` end).
-3. **Aggregate by account**: sum the posted amounts per ledger account, then group revenue accounts and expense accounts.
-4. **Net result** = total produits (revenue) − total charges (expenses).
+3. **Scope the period** with a `whereClause` on the posting/entry date (e.g. `_gte` start, `_lte` end).
+4. **Aggregate by account**: sum the posted amounts per ledger account, then group revenue accounts and expense accounts.
+5. **Net result** = total produits (revenue) − total charges (expenses).
 
 ## Do NOT
 
@@ -27,4 +30,4 @@ If `journal_entries` / `ledger_accounts` return no rows for the workspace, the b
 
 ## Present it
 
-Group the output as: Produits (revenue) lines → total; Charges (expense) lines → total; **Résultat net**. Note the currency and the period. Offer a month-by-month or category breakdown as a follow-up.
+The coverage line first (`well:data-coverage`), then: Produits (revenue) lines → total; Charges (expense) lines → total; **Résultat net**. Note the currency and the period. Offer a month-by-month or category breakdown as a follow-up.

--- a/plugins/well/skills/data-coverage/SKILL.md
+++ b/plugins/well/skills/data-coverage/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: data-coverage
+description: Check whether a Well workspace's data is complete enough to answer a financial question — bank source connected and healthy, transactions categorized — and offer the control that closes each gap (the connect card for a missing bank, the named rows for missing categories). Use BEFORE producing any figure, table, or chart from Well data, and whenever the user asks why a number looks wrong, low, or incomplete.
+---
+
+# Data coverage — what the figures are missing
+
+A financial figure is only as complete as the data under it. Two gaps make a Well
+answer quietly wrong rather than visibly wrong, and neither announces itself:
+
+1. **No bank source, or an unhealthy one.** Cash movement that was never synced
+   cannot appear in a cash position, a runway, a P&L, or a reconciliation. The
+   number computes, looks plausible, and is missing a whole account.
+2. **Uncategorized transactions.** Money that moved but carries no category
+   lands nowhere in a cost structure or an expense breakdown. The categories
+   shown are real; the total under them is not the total that moved.
+
+Both are checked **before** the figure is produced — not mentioned afterwards —
+and both carry the action that closes them. Reporting a gap the user cannot act
+on is a complaint, not a diagnosis.
+
+## Run the gate
+
+### 1. Is there banking data at all?
+
+Detect from the DATA, not from the connector catalog — a connector can be
+connected and still have synced nothing.
+
+```
+well_query_records({ root: "accounts", fields: [["accounts","account_id"]], limit: 1 })
+well_query_records({ root: "transactions", fields: [["transactions","transaction_id"]],
+                     whereClause: { <the period's date field>: { _gte: <start>, _lte: <end> } },
+                     limit: 1 })
+```
+
+- **No accounts** → there is no bank source. This is a blocker for anything
+  cash-shaped; say so before computing.
+- **Accounts but no transactions in the period** → the source exists but the
+  period is not covered (sync gap, or a genuinely dormant month — say which you
+  can and cannot tell apart).
+
+### 2. No bank source → CALL `well_list_connectors`
+
+Do not describe the fix in prose. **Call the tool.** In a host that renders MCP
+app widgets (Claude Desktop), `well_list_connectors` draws the Well connect
+card — the searchable provider picker, each tile with its logo and a one-click
+install — which is the affordance the user actually needs. Summarising the
+catalog into a paragraph replaces a working control with a description of one.
+
+- Know which bank? `q: "<bank name>"` — the long tail is only reachable by
+  search, so a specific bank must be searched for by name.
+- Don't know? Call it with no `q` for the curated, matched-first view.
+- The tool takes no category filter today, so "show me the banks" is expressed
+  as a name search, not as a category.
+
+Every entry carries `is_connected`, `connection_status`, and an **`install_url`**.
+In a text-only host no card renders, so hand over the `install_url` directly —
+the link works either way, and it survives being signed out or having no
+workspace yet.
+
+**A connected-but-unhealthy connector is a different errand.** It shows in
+`connection_status`; name it and say the sync is stale or failing. Telling
+someone to connect a bank they already connected is how a real diagnosis reads
+as noise.
+
+### 3. How much is uncategorized?
+
+`transactions.category_status` is a typed enum — `categorized`,
+`uncategorized`, `classifier_abstained`, `classifier_failed`, `pending`,
+`legacy_unmapped` — and it is **null on a row nothing has looked at yet**. So
+"not categorized" is *not* `_neq: "categorized"`, which drops the nulls and
+undercounts the gap:
+
+```json
+{ "_and": [
+    { "<date field>": { "_gte": "<start>", "_lte": "<end>" } },
+    { "_or": [
+        { "category_status": { "_is_null": true } },
+        { "category_status": { "_neq": "categorized" } }
+    ]}
+]}
+```
+
+Report the count against the period's total, and **list the rows** (counterparty,
+date, amount) rather than only the number — a list is something the user can act
+on, a count is not. The statuses are worth distinguishing when you name them:
+`pending` is work in flight, `classifier_abstained` / `classifier_failed` are
+rows that need a human decision, `uncategorized` / null have not been attempted.
+
+Categorizing is done in the Well app on the transactions the list names; there is
+no MCP write for it, so point at the rows, don't promise to fix them.
+
+## Prefer the tools that already report their own coverage
+
+`well_get_runway`, `well_get_cash_position` and `well_get_cost_structure` compute
+deterministically server-side — the same numbers the Well app shows — and each
+returns its own completeness signals:
+
+- `status: "insufficient_data"` — not enough connected data to compute at all.
+  Say that, and go to step 2; do not substitute a hand-rolled estimate.
+- `partial: true` with `excluded: { accounts, transactions }` — rows were left
+  out (a missing FX rate, an unsupported account). Report the counts; never
+  present the figure as unconditionally complete.
+- `hints[]` — each with a `detected_gap` and a `suggested_action`, already
+  written for the user.
+
+Rebuilding these from raw `well_query_records` reads throws every one of those
+signals away and produces a number that cannot tell you what it is missing.
+That is the failure this skill exists to prevent.
+
+## Report it
+
+A **coverage line above the figure**, never a footnote below it:
+
+> Coverage: 2 accounts, 1 Jan–31 Mar. **41 of 380 transactions uncategorized**
+> (12 pending, 29 need a decision). Revolut is connected but last synced 18 days ago.
+
+Then the figure. Then, if a gap is open, the action — the `install_url` for a
+missing bank, the named rows for missing categories. When coverage is clean, say
+so in one clause and move on; silence reads as unchecked, not as complete.
+
+## Rules
+
+- **Gate, don't annotate.** The check runs before the figure exists. A caveat
+  added after the fact is read after the number has already been believed.
+- **Never present a partial figure as complete.** If a gap is open, the figure
+  is labelled with it in the same breath, in the same block.
+- **Offer the control, not a description of it.** A missing bank source means
+  calling `well_list_connectors` so its connect card renders — not writing a
+  sentence about connecting a bank. The same applies to the named transaction
+  rows: a list the user can work through beats a count they cannot.
+- **Say what you cannot tell apart.** A month with no transactions may be a sync
+  gap or a dormant month; the data alone does not distinguish them. Say which.

--- a/plugins/well/skills/month-end-close/SKILL.md
+++ b/plugins/well/skills/month-end-close/SKILL.md
@@ -10,11 +10,12 @@ Closing is a **repeatable checklist, not a heroic event** — and every step has
 ## The checklist
 
 1. **Discover the schema first** (see `well:querying-well-data`) and fix the period (date range).
-2. **Bank reconciliation** — every `transactions` row in the period is matched to its invoice(s) or categorised; no unexplained movements. Use `well:reconciliation`. Confirm `account_balances` match the bank's closing balance.
-3. **Receivables / payables** — open `invoices` reviewed; nothing miscoded; AR aging sane (`well:ar-aging`).
-4. **Posting status** — every transaction and invoice in the period is **posted to a journal entry** (not left DRAFT). Query `journal_entries` for the period and flag any source document with no posted entry — those are the gaps that block a clean close.
-5. **Balances** — trial balance balances (total debits = total credits) across `ledger_accounts` / `journal_entries`; `account_balances` reconciled.
-6. **Tax** — VAT/tax for the period computed from the now-posted ledger (`well:vat-summary`).
+2. **Source completeness** — run the coverage gate (`well:data-coverage`): a bank source exists and is healthy, and the period's transactions are categorized. This is the first blocker, not a caveat: a period whose cash movement was never synced cannot be reconciled, and one whose transactions carry no category cannot be posted to the right accounts. Report each gap with its action — the `install_url` for a missing source, the named rows for missing categories.
+3. **Bank reconciliation** — every `transactions` row in the period is matched to its invoice(s) or categorised; no unexplained movements. Use `well:reconciliation`. Confirm `account_balances` match the bank's closing balance.
+4. **Receivables / payables** — open `invoices` reviewed; nothing miscoded; AR aging sane (`well:ar-aging`).
+5. **Posting status** — every transaction and invoice in the period is **posted to a journal entry** (not left DRAFT). Query `journal_entries` for the period and flag any source document with no posted entry — those are the gaps that block a clean close.
+6. **Balances** — trial balance balances (total debits = total credits) across `ledger_accounts` / `journal_entries`; `account_balances` reconciled.
+7. **Tax** — VAT/tax for the period computed from the now-posted ledger (`well:vat-summary`).
 
 ## Rules
 

--- a/plugins/well/skills/querying-well-data/SKILL.md
+++ b/plugins/well/skills/querying-well-data/SKILL.md
@@ -5,12 +5,43 @@ description: How to query a Well workspace correctly — discover the schema fir
 
 # Querying Well data
 
-Well exposes a workspace's financial graph through three MCP tools:
+Well exposes a workspace's financial graph through these MCP tools:
 
 - `well_get_schema()` — list every available **root** (entity type).
 - `well_get_schema({ root })` — list the fields available on one root, with types and semantic context.
 - `well_query_records({ root, fields, whereClause?, orderBy?, limit? })` — read rows.
 - `well_get_entity({ root, id })` — fetch one record by id.
+- `well_list_workspaces()` — the workspaces this connection authorizes (see "Scope first" below).
+- `well_list_connectors({ q? })` — the connectable catalog, each entry with `is_connected`, `connection_status`, and an `install_url` deep link.
+- `well_get_runway()` / `well_get_cash_position()` / `well_get_cost_structure()` — **deterministic KPIs computed server-side**, identical to what the Well app shows, each reporting its own completeness (`status`, `partial`, `excluded`, `hints`). Prefer these over re-deriving the same figure from raw reads, which throws those signals away.
+
+## Scope first: which workspace are you answering for?
+
+One connection can authorize several workspaces. When it does and you pass no
+`workspace_id`, a read **fans out across all of them and merges the rows into one
+flat result** — every row tagged with its own `workspace_id`, but a single figure
+computed over the merge belongs to no one company.
+
+So before answering a question about "the" business:
+
+1. `well_list_workspaces()` — it returns each workspace's id, name, and the
+   company identity behind it (registered name, trade name, country, currency,
+   fiscal year start) so two similarly-named workspaces can be told apart.
+2. Pass `workspace_id` on every subsequent call, unless the user genuinely asked
+   for the consolidated view.
+3. **Name the workspace in the answer.** Every table, figure and chart states
+   which company it is for, alongside its period and currency. A number whose
+   owner is unstated is the one error a reader cannot catch.
+
+Writes never guess: with more than one authorized workspace and no
+`workspace_id`, a write is refused rather than sent to the default.
+
+## Then check coverage
+
+Before producing any figure, run the coverage gate — `well:data-coverage`. It
+checks that a bank source exists and is healthy, and that the period's
+transactions are categorized, and reports each gap with the action that closes
+it. A figure computed over incomplete data is wrong in a way that looks right.
 
 ## The one rule: discover before you query
 
@@ -38,8 +69,16 @@ If you are about to answer a financial question by reconstructing it from raw in
 - `text` → `_eq`, `_like`, `_ilike`
 - relations → nest: `{ "issuer": { "name": { "_ilike": "%acme%" } } }`
 
+**`_neq` on a nullable enum drops the nulls.** A row whose status was never set
+matches neither `_eq` nor `_neq`, so filtering "everything that isn't X" with
+`_neq` silently undercounts by however many rows are null. Spell both out:
+
+```json
+{ "_or": [ { "field": { "_is_null": true } }, { "field": { "_neq": "x" } } ] }
+```
+
 ## Gotchas
 
-- Reads are scoped to the authenticated workspace automatically — you never pass a workspace id.
+- A read is scoped to the workspace you name in `workspace_id`; omit it with several authorized workspaces and it fans out across all of them (see "Scope first" above).
 - Select the specific fields you need (5–15), not everything — it is faster and cheaper.
 - Amounts on commercial documents are in the document currency; check the schema `context` for currency fields before summing across currencies (see `exchange_rates`).

--- a/plugins/well/skills/reconciliation/SKILL.md
+++ b/plugins/well/skills/reconciliation/SKILL.md
@@ -29,4 +29,4 @@ Well's pipelines maintain the link between a bank transaction and the invoice(s)
 
 ## Present it
 
-Three buckets — **Matched**, **Unpaid invoices**, **Unexplained transactions** — each with counts and totals, plus the currency. Offer to drill into any bucket with `well_get_entity`.
+The coverage line first (`well:data-coverage`) — an unsynced period makes every invoice in it look unpaid — then three buckets: **Matched**, **Unpaid invoices**, **Unexplained transactions**, each with counts and totals, plus the currency. Offer to drill into any bucket with `well_get_entity`.

--- a/plugins/well/skills/vat-summary/SKILL.md
+++ b/plugins/well/skills/vat-summary/SKILL.md
@@ -9,11 +9,14 @@ A VAT return is a **byproduct of closed books**, not a separate project. If the 
 
 ## Build it from the posted ledger + tax rates
 
-1. **Discover the schema first** (see `well:querying-well-data`).
-2. **Output VAT (collected on sales)** — from issued `invoices` / `invoice_items` and their `tax_rates`, or the corresponding VAT `ledger_accounts` / `journal_entries` for the period. Group by rate (standard / reduced / zero / exempt).
-3. **Input VAT (paid on purchases)** — from received `invoices` / `invoice_items` + `tax_rates`, or the input-VAT ledger accounts.
-4. **Net VAT due** = output VAT − recoverable input VAT, per the period's date filter.
-5. **By rate and jurisdiction** — break the totals down by VAT rate and, for multi-jurisdiction workspaces, by jurisdiction. Read the rate from the data (`tax_rates`), don't assume it.
+1. **Run the coverage gate** (see `well:data-coverage`). A declaration computed over a
+   period whose transactions are unsynced or uncategorized is the one figure here with a
+   filing consequence — check before computing, never after.
+2. **Discover the schema** (see `well:querying-well-data`).
+3. **Output VAT (collected on sales)** — from issued `invoices` / `invoice_items` and their `tax_rates`, or the corresponding VAT `ledger_accounts` / `journal_entries` for the period. Group by rate (standard / reduced / zero / exempt).
+4. **Input VAT (paid on purchases)** — from received `invoices` / `invoice_items` + `tax_rates`, or the input-VAT ledger accounts.
+5. **Net VAT due** = output VAT − recoverable input VAT, per the period's date filter.
+6. **By rate and jurisdiction** — break the totals down by VAT rate and, for multi-jurisdiction workspaces, by jurisdiction. Read the rate from the data (`tax_rates`), don't assume it.
 
 ## Rules — conservative by design
 
@@ -24,4 +27,4 @@ A VAT return is a **byproduct of closed books**, not a separate project. If the 
 
 ## Present it
 
-Output VAT (by rate) → total; Input VAT (by rate) → total; **Net VAT due**; the period and jurisdiction; a books-closed/draft status line; and any flagged uncertainties for review.
+The coverage line first (`well:data-coverage`), then: Output VAT (by rate) → total; Input VAT (by rate) → total; **Net VAT due**; the period and jurisdiction; a books-closed/draft status line; and any flagged uncertainties for review.


### PR DESCRIPTION
## Problem

From Maxime, after client calls: the charts the skills produce are **incomplete**, and nothing says so. Two gaps, neither of which announces itself:

1. **No bank source** — cash movement that was never synced can't appear in a cash position, a runway, a P&L or a reconciliation. The number computes, looks plausible, and is missing a whole account.
2. **Uncategorized transactions** — money that moved but carries no category lands nowhere in a cost structure. The categories shown are real; the total under them isn't the total that moved.

The close-books flow already treats both as blockers (`CLOSE_BLOCKER_CODE.MISSING_BANK_CONNECTOR` / `CONNECTOR_UNHEALTHY` / `UNCATEGORIZED_TRANSACTIONS`, each mapped to one errand). The analysis skills checked neither.

## What changed

### New `well:data-coverage` — a gate, not a caveat

Runs **before** the figure exists, and for each gap offers the **control** rather than a description of one:

- **No bank source → call `well_list_connectors`.** That tool renders the Well connect card — the searchable provider picker with one-click install — in widget-capable hosts. The skill says to call it rather than summarise the catalog into a paragraph, which replaces a working control with prose about one. `install_url` is the text-only fallback. A connected-but-unhealthy connector is named as its own errand, not as "connect a bank" to someone who already did.
- **Uncategorized transactions → the named rows**, not a count. `transactions.category_status` is a typed enum that is **NULL until something looks at the row**, so the filter spells out the null branch — `_neq: "categorized"` alone drops the nulls and silently undercounts the gap. The statuses are distinguished when named: `pending` is work in flight, `classifier_abstained`/`classifier_failed` need a human decision.
- **Detection from the data, remediation from the catalog** — a connector can be connected and have synced nothing, so the presence check reads `accounts`/`transactions`, not the connector list.

Wired in as step 1 of `compte-de-resultat`, `balance-sheet`, `vat-summary`, `ar-aging`, `reconciliation` and `month-end-close`, with the coverage line carried into each "Present it".

### `cash-flow-forecast` no longer hand-rolls runway

It told the model to rebuild runway from `account_balances`. `well_get_runway` already computes it server-side — with the sign-convention detection, internal-transfer exclusion and FX conversion a hand-rolled sum gets wrong — and returns `status: "insufficient_data"`, `partial`, `excluded: {accounts, transactions}` and `hints[]`. **Every completeness signal a re-derivation destroys is exactly what this PR is about.** Now starts from the tool and carries those signals into the output.

### `querying-well-data` said something false

> "Reads are scoped to the authenticated workspace automatically — you never pass a workspace id."

Untrue on a multi-workspace token: the read fans out across the grant set and **merges the rows into one flat result**, so a single figure can span two companies. Replaced with a scope-first step (`well_list_workspaces` → pass `workspace_id` → name the workspace in the answer). The tool list was also missing `well_list_workspaces`, `well_list_connectors` and the three deterministic KPI tools; the README's list was staler still.

## Verification

- All 10 skills: frontmatter parses, `name` matches its directory, descriptions within limits
- Every `well:<skill>` cross-reference resolves (no dangling refs)
- Ordered lists renumbered after the inserted step
- `category_status` confirmed exposed to `well_query_records` (`fields-transactions.json`) and its enum values taken from `TransactionCategoryStatusEnum`, not guessed
- `well_list_connectors` confirmed to be in the platform's `UI_TOOL_NAMES` and mapped to the `ConnectProviders` widget — so "call the tool and the connect card renders" is a real behaviour, not an aspiration
- Plugin version 0.2.0 → 0.3.0

## Known limitation

`well_list_connectors` has no category filter, so "show me the banks" is expressed as a name search (`q`) or the curated view. A `category_id` filter on that tool would make the missing-bank case one clean call — worth a follow-up on the platform side.

## Related

Companion fix on the platform: WellApp-ai/platform#5778 makes every MCP widget name the workspace(s) its result belongs to, which was the other half of the same feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYLCkxuwbzp85jUwRUYaAF