### PR TITLE
test(extractor): make two flaky tests deterministic

### DIFF
--- a/ai-invoice-extractor/tests/error-handling.test.ts
+++ b/ai-invoice-extractor/tests/error-handling.test.ts
@@ -96,8 +96,10 @@ describe("Error Handling", () => {
           stdio: "pipe"
         })
       } catch (error: any) {
-        // Either filesystem error or CLI error is acceptable
-        expect(error.status).toBe(1)
+        // The file is valid, so the CLI reaches the provider with a fake key.
+        // With network access the provider answers 401 (exit 1); without it the
+        // call fails as a processing error (exit 2). Both are correct handling.
+        expect([1, 2]).toContain(error.status)
       }
     })
   })

--- a/ai-invoice-extractor/tests/integration/extractor-integration.test.ts
+++ b/ai-invoice-extractor/tests/integration/extractor-integration.test.ts
@@ -791,10 +791,10 @@ describe('AI Invoice Extractor Integration Tests', () => {
 
 	async function mockBatchProcessing(params: any) {
 		// Simulate batch processing
-		const processed = params.documents.map((doc: any) => ({
+		const processed = params.documents.map((doc: any, index: number) => ({
 			...doc,
 			processed: true,
-			success: Math.random() > 0.1, // 90% success rate
+			success: index % 10 !== 9, // 9 of 10 succeed, deterministically
 			processingTime: Math.random() * 1500 + 300, // 0.3-1.8 seconds per document
 		}));
 


### PR DESCRIPTION
Two tests in the extractor suite depended on chance and failed on the Dependabot PRs #378, #372 and #369 for reasons unrelated to the bumps.

- `tests/integration/extractor-integration.test.ts`: the batch mock picked success at random (90%) and asserted at least 8 of 10. It now succeeds for 9 of 10 documents by index.
- `tests/error-handling.test.ts`: the long-path test reaches the provider with a fake key and only got exit 1 when the network answered 401. It now accepts the processing-error exit (2) as well.

Verified locally: integration file 3/3 runs green, error-handling 18/18.